### PR TITLE
Kia: gate vehicleKey guard on non-Europe regions (fix infinite recursion)

### DIFF
--- a/BetterBlue/Models/Account.swift
+++ b/BetterBlue/Models/Account.swift
@@ -358,7 +358,7 @@ extension BBAccount {
         }
 
         // For Kia vehicles, ensure vehicleKey is populated by refreshing if needed
-        if brandEnum == .kia && bbVehicle.vehicleKey == nil {
+        if brandEnum == .kia && regionEnum != .europe && bbVehicle.vehicleKey == nil {
             BBLogger.debug(.api, "BBAccount: Kia vehicle missing vehicleKey, fetching fresh data...")
             try await loadVehicles(modelContext: modelContext)
             return try await fetchVehicleStatus(for: bbVehicle, modelContext: modelContext, cached: cached)
@@ -523,7 +523,7 @@ extension BBAccount {
         }
 
         // For Kia vehicles, ensure vehicleKey is populated by refreshing if needed
-        if brandEnum == .kia && bbVehicle.vehicleKey == nil {
+        if brandEnum == .kia && regionEnum != .europe && bbVehicle.vehicleKey == nil {
             BBLogger.debug(.api, "BBAccount: Kia vehicle missing vehicleKey, fetching fresh data...")
             let fetchedVehicles = try await api.fetchVehicles(authToken: authToken)
 


### PR DESCRIPTION
## Summary

In `BBAccount.fetchVehicleStatus` (Account.swift:361) and `sendCommand`
(Account.swift:526), the `vehicleKey == nil` guard for Kia triggers
`loadVehicles` + a recursive call to refresh the missing key.

For Kia EU, `vehicleKey` is **never** populated — only
`KiaUSAAPIClient+Parsing.swift:114` sets it. The guard therefore fires
every time on Kia EU accounts, producing infinite async recursion.
`CachedAPIClient` dedupes the inner `fetchVehicles` within its 5s TTL,
so only one HTTP call is logged, but the recursive `await` chain keeps
growing — manifesting as a never-ending status spinner, frozen UI,
and eventual crash.

Adding `&& regionEnum != .europe` gates the guard to the Bluelink-style
regions (USA today; Canada/Australia when those stubbed clients get
real implementations) where the API actually uses `vehicleKey` in
request headers (`KiaUSAAPIClient.swift:90`). Kia Europe uses the
CCS2 architecture and identifies vehicles by `regId` in the URL —
it has no `vehicleKey` concept.

## Test plan

- [x] Reproduced infinite spinner + crash on BetterBlue 2026.5.8
      (TestFlight) with a Kia EV9 (Europe)
- [x] Verified `fetchVehicleStatus` works in isolation via `bbcli`
      against the same vehicle (~0.34s end-to-end)
- [x] Side-loaded fixed build to physical iPhone — status fetches
      complete and the app remains responsive

## AI disclosure

Authored with Claude Code (Anthropic).