### PR TITLE
feat: add React Native (Expo) project scaffold

### DIFF
--- a/BetterBlueRN/.gitignore
+++ b/BetterBlueRN/.gitignore
@@ -1,0 +1,38 @@
+# OSX
+.DS_Store
+
+# Node
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# Expo
+.expo/
+dist/
+web-build/
+
+# Native
+*.orig.*
+*.jks
+*.p8
+*.p12
+*.key
+*.mobileprovision
+
+# Metro
+.metro-health-check*
+
+# debug
+npm-debug.*
+yarn-debug.*
+yarn-error.*
+
+# macOS
+*.pem
+
+# local env files
+.env*.local
+.env
+
+# typescript
+*.tsbuildinfo

--- a/BetterBlueRN/SETUP.md
+++ b/BetterBlueRN/SETUP.md
@@ -1,0 +1,57 @@
+# BetterBlue React Native Setup
+
+## Prerequisites
+
+- Node.js 18+
+- npm or yarn
+- Expo CLI: `npm install -g expo-cli`
+- iOS: Xcode + iOS Simulator (macOS only)
+- Android: Android Studio + Android Emulator
+
+## Install Dependencies
+
+```bash
+cd BetterBlueRN
+npm install
+```
+
+## Start Development Server
+
+```bash
+npx expo start
+```
+
+> **Note:** Expo Go will NOT work because this project uses custom native modules (expo-secure-store, expo-notifications, react-native-maps). You must use a development build.
+
+## Create Development Build
+
+### iOS (macOS only)
+```bash
+npx expo run:ios
+```
+
+### Android
+```bash
+npx expo run:android
+```
+
+## About the API
+
+BetterBlue uses the unofficial Hyundai BlueLink and Kia Connect APIs. These are not officially documented and may change at any time. The implementations are based on the open-source [bluelinky](https://github.com/Hacksore/bluelinky) project and the [hyundai_kia_connect_api](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api) Python library.
+
+## Test Accounts
+
+Use a username starting with `fake@` or `test@` to activate fake vehicle mode. No real API calls are made and any password works.
+
+- Username: `fake@test.com`
+- Password: `anything`
+- PIN: `1234`
+
+## Architecture Notes
+
+- API clients: `src/api/`
+- State management: Zustand (`src/store/`)
+- Navigation: Expo Router (file-based routing in `app/`)
+- Styling: NativeWind v4 (Tailwind CSS for React Native)
+- Secure credentials: expo-secure-store
+- Local data cache: expo-sqlite

--- a/BetterBlueRN/app.json
+++ b/BetterBlueRN/app.json
@@ -1,0 +1,34 @@
+{
+  "expo": {
+    "name": "BetterBlue",
+    "slug": "better-blue",
+    "version": "1.0.0",
+    "scheme": "betterblue",
+    "orientation": "portrait",
+    "userInterfaceStyle": "automatic",
+    "newArchEnabled": true,
+    "splash": {
+      "backgroundColor": "#0f172a",
+      "resizeMode": "contain"
+    },
+    "ios": {
+      "bundleIdentifier": "com.markschmidt.betterblue",
+      "supportsTablet": true,
+      "infoPlist": {
+        "NSLocationWhenInUseUsageDescription": "BetterBlue uses your location to show your vehicle on the map.",
+        "NSLocationAlwaysAndWhenInUseUsageDescription": "BetterBlue uses your location to show your vehicle on the map."
+      }
+    },
+    "android": {
+      "package": "com.markschmidt.betterblue",
+      "permissions": ["ACCESS_COARSE_LOCATION", "ACCESS_FINE_LOCATION"]
+    },
+    "plugins": [
+      "expo-router",
+      "expo-secure-store",
+      ["expo-notifications", { "color": "#1a73e8" }],
+      ["expo-location", { "locationWhenInUsePermission": "BetterBlue uses your location to show your vehicle on the map." }]
+    ],
+    "experiments": { "typedRoutes": true }
+  }
+}

--- a/BetterBlueRN/babel.config.js
+++ b/BetterBlueRN/babel.config.js
@@ -1,0 +1,9 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: [
+      ['babel-preset-expo', { jsxImportSource: 'nativewind' }],
+      'nativewind/babel',
+    ],
+  };
+};

--- a/BetterBlueRN/global.css
+++ b/BetterBlueRN/global.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/BetterBlueRN/metro.config.js
+++ b/BetterBlueRN/metro.config.js
@@ -1,0 +1,4 @@
+const { getDefaultConfig } = require('expo/metro-config');
+const { withNativeWind } = require('nativewind/metro');
+const config = getDefaultConfig(__dirname);
+module.exports = withNativeWind(config, { input: './global.css' });

--- a/BetterBlueRN/package.json
+++ b/BetterBlueRN/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "better-blue-rn",
+  "version": "1.0.0",
+  "main": "expo-router/entry",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios"
+  },
+  "dependencies": {
+    "expo": "~52.0.0",
+    "expo-router": "~4.0.0",
+    "react": "18.3.1",
+    "react-native": "0.76.3",
+    "expo-status-bar": "~2.0.0",
+    "expo-sqlite": "~15.0.0",
+    "expo-secure-store": "~14.0.0",
+    "expo-location": "~18.0.0",
+    "expo-notifications": "~0.29.0",
+    "expo-linking": "~7.0.0",
+    "expo-constants": "~17.0.0",
+    "expo-crypto": "~14.0.0",
+    "react-native-reanimated": "~3.16.0",
+    "react-native-gesture-handler": "~2.20.0",
+    "react-native-safe-area-context": "~4.12.0",
+    "react-native-screens": "~4.1.0",
+    "react-native-maps": "~1.18.0",
+    "@gorhom/bottom-sheet": "^5.0.0",
+    "nativewind": "^4.0.36",
+    "tailwindcss": "^3.4.0",
+    "zustand": "^5.0.0",
+    "@react-native-async-storage/async-storage": "2.1.0",
+    "react-native-svg": "~15.8.0",
+    "react-native-get-random-values": "~1.11.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.24.0",
+    "@types/react": "~18.3.0",
+    "typescript": "~5.3.0"
+  }
+}

--- a/BetterBlueRN/src/api/APIClientFactory.ts
+++ b/BetterBlueRN/src/api/APIClientFactory.ts
@@ -1,0 +1,29 @@
+import { APIClient, APIClientConfiguration, APIError } from './types';
+import { FakeAPIClient } from './FakeAPIClient';
+import { HyundaiUSClient } from './HyundaiUSClient';
+import { KiaUSClient } from './KiaUSClient';
+import { CachedAPIClient } from './CachedAPIClient';
+
+function isTestAccount(username: string): boolean {
+  const lower = username.toLowerCase();
+  return lower.startsWith('fake@') || lower.startsWith('test@');
+}
+
+export function createAPIClient(config: APIClientConfiguration): APIClient {
+  if (config.brand === 'fake' || isTestAccount(config.username)) {
+    return new FakeAPIClient(config);
+  }
+
+  if (config.brand === 'hyundai' && config.region === 'US') {
+    return new CachedAPIClient(new HyundaiUSClient(config));
+  }
+
+  if (config.brand === 'kia' && config.region === 'US') {
+    return new CachedAPIClient(new KiaUSClient(config));
+  }
+
+  throw new APIError(
+    `Region ${config.region} is not supported for brand ${config.brand}`,
+    'regionNotSupported',
+  );
+}

--- a/BetterBlueRN/src/api/CachedAPIClient.ts
+++ b/BetterBlueRN/src/api/CachedAPIClient.ts
@@ -1,0 +1,94 @@
+/**
+ * Caching wrapper for any APIClient.
+ *
+ * - `fetchVehicleStatus` results are cached for 5 seconds per VIN.
+ * - Concurrent identical requests are deduplicated: callers share the same
+ *   in-flight promise rather than each issuing a separate network call.
+ * - All other APIClient methods are forwarded to the delegate unchanged.
+ */
+import type {
+  APIClient,
+  EVTripDetail,
+  MFAMethod,
+  Vehicle,
+  VehicleCommand,
+  VehicleStatus,
+} from './types';
+
+const CACHE_TTL_MS = 5_000;
+
+interface CacheEntry {
+  status: VehicleStatus;
+  expiresAt: number;
+}
+
+export class CachedAPIClient implements APIClient {
+  private readonly delegate: APIClient;
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly pending = new Map<string, Promise<VehicleStatus>>();
+
+  constructor(delegate: APIClient) {
+    this.delegate = delegate;
+  }
+
+  // ── Passthrough methods ────────────────────────────────────────────────
+
+  initialize = () => this.delegate.initialize();
+  fetchVehicles = () => this.delegate.fetchVehicles();
+  sendCommand = (v: Vehicle, c: VehicleCommand) => this.delegate.sendCommand(v, c);
+  fetchEVTripDetails = (vin: string): Promise<EVTripDetail[] | null> =>
+    this.delegate.fetchEVTripDetails?.(vin) ?? Promise.resolve(null);
+  supportsMFA = () => this.delegate.supportsMFA();
+  sendMFACode = (xid: string, otpKey: string, method: MFAMethod) =>
+    this.delegate.sendMFACode(xid, otpKey, method);
+  verifyMFACode = (xid: string, otpKey: string, code: string) =>
+    this.delegate.verifyMFACode(xid, otpKey, code);
+  completeMFALogin = (sid: string, rmToken: string) =>
+    this.delegate.completeMFALogin(sid, rmToken);
+
+  // ── Cached + deduplicated fetchVehicleStatus ───────────────────────────
+
+  async fetchVehicleStatus(
+    vin: string,
+    regId: string,
+    vehicleKey?: string,
+    cached = true,
+  ): Promise<VehicleStatus> {
+    const cacheKey = `${vin}:${cached}`;
+    const pendingKey = `${vin}:${cached}:pending`;
+
+    // Serve from cache if within TTL (only when caller requested cached data)
+    if (cached) {
+      const entry = this.cache.get(cacheKey);
+      if (entry && entry.expiresAt > Date.now()) {
+        return entry.status;
+      }
+    }
+
+    // Deduplicate: return in-flight promise if one exists
+    const inFlight = this.pending.get(pendingKey);
+    if (inFlight) return inFlight;
+
+    const promise = this.delegate
+      .fetchVehicleStatus(vin, regId, vehicleKey, cached)
+      .then((status) => {
+        this.cache.set(cacheKey, { status, expiresAt: Date.now() + CACHE_TTL_MS });
+        this.pending.delete(pendingKey);
+        return status;
+      })
+      .catch((err: unknown) => {
+        this.pending.delete(pendingKey);
+        throw err;
+      });
+
+    this.pending.set(pendingKey, promise);
+    return promise;
+  }
+
+  /** Evict all cached status for a VIN (e.g. immediately after sending a command). */
+  invalidate(vin: string): void {
+    for (const key of this.cache.keys()) {
+      if (key.startsWith(`${vin}:`)) this.cache.delete(key);
+    }
+  }
+}

--- a/BetterBlueRN/src/api/FakeAPIClient.ts
+++ b/BetterBlueRN/src/api/FakeAPIClient.ts
@@ -1,0 +1,189 @@
+/**
+ * Fake API Client for testing and development.
+ *
+ * Returns deterministic fake vehicle data without making real API calls.
+ * Activate by using a username that starts with `fake@` or `test@`.
+ */
+import type {
+  APIClient,
+  AuthToken,
+  APIClientConfiguration,
+  ClimateStatus,
+  EVTripDetail,
+  FuelType,
+  LockStatus,
+  MFAMethod,
+  Vehicle,
+  VehicleCommand,
+  VehicleStatus,
+} from './types';
+import { APIError } from './types';
+
+const FAKE_VEHICLES: Omit<Vehicle, 'accountId'>[] = [
+  {
+    id: 'FAKE_VIN_EV_001',
+    vin: 'FAKE_VIN_EV_001',
+    regId: 'FAKE_REG_EV_001',
+    model: 'Ioniq 6',
+    fuelType: 'electric',
+    generation: 2,
+    isHidden: false,
+    sortOrder: 0,
+    backgroundColorName: 'default',
+    chargePortType: 'CCS1',
+    enableSeatHeatControls: true,
+    vehicleKey: 'FAKE_VK_EV_001',
+  },
+  {
+    id: 'FAKE_VIN_GAS_001',
+    vin: 'FAKE_VIN_GAS_001',
+    regId: 'FAKE_REG_GAS_001',
+    model: 'Tucson',
+    fuelType: 'gas',
+    generation: 2,
+    isHidden: false,
+    sortOrder: 1,
+    backgroundColorName: 'default',
+    chargePortType: 'CCS1',
+    enableSeatHeatControls: false,
+  },
+];
+
+interface FakeVehicleState {
+  locked: boolean;
+  climateOn: boolean;
+  temperature: number;
+  batteryLevel: number;
+  isCharging: boolean;
+}
+
+const defaultState = (): FakeVehicleState => ({
+  locked: true,
+  climateOn: false,
+  temperature: 70,
+  batteryLevel: 80,
+  isCharging: false,
+});
+
+export class FakeAPIClient implements APIClient {
+  private readonly config: APIClientConfiguration;
+  private readonly state = new Map<string, FakeVehicleState>();
+
+  constructor(config: APIClientConfiguration) {
+    this.config = config;
+  }
+
+  async initialize(): Promise<void> {
+    // No-op
+  }
+
+  supportsMFA(): boolean {
+    return false;
+  }
+
+  private fakeToken(): AuthToken {
+    return {
+      accessToken: 'fake_access_token',
+      expiresAt: Date.now() + 3600 * 1000,
+    };
+  }
+
+  private getState(vin: string): FakeVehicleState {
+    if (!this.state.has(vin)) this.state.set(vin, defaultState());
+    return this.state.get(vin)!;
+  }
+
+  async fetchVehicles(): Promise<Vehicle[]> {
+    await this.delay(300);
+    return FAKE_VEHICLES.map((v) => ({ ...v, accountId: this.config.accountId }));
+  }
+
+  async fetchVehicleStatus(
+    vin: string,
+    _regId: string,
+    _vehicleKey?: string,
+    _cached?: boolean,
+  ): Promise<VehicleStatus> {
+    await this.delay(600);
+    const s = this.getState(vin);
+    const isEV = FAKE_VEHICLES.find((v) => v.vin === vin)?.fuelType === 'electric';
+
+    const lockStatus: LockStatus = { locked: s.locked };
+    const climateStatus: ClimateStatus = {
+      airControlOn: s.climateOn,
+      temperature: s.temperature,
+      defrostOn: false,
+    };
+
+    return {
+      lastUpdated: Date.now(),
+      lockStatus,
+      climateStatus,
+      location: { latitude: 47.6062, longitude: -122.3321 },
+      battery12V: 95,
+      doorOpen: { frontLeft: false, frontRight: false, rearLeft: false, rearRight: false },
+      trunkOpen: false,
+      hoodOpen: false,
+      ...(isEV
+        ? {
+            evStatus: {
+              batteryLevel: s.batteryLevel,
+              range: { length: Math.round((s.batteryLevel / 100) * 266), units: 'miles' },
+              chargeStatus: s.isCharging ? 'charging' : 'not_charging',
+              isCharging: s.isCharging,
+              isPluggedIn: s.isCharging,
+              chargeRemainingMinutes: s.isCharging ? 45 : 0,
+              acTargetSOC: 80,
+              dcTargetSOC: 80,
+            },
+          }
+        : {
+            gasRange: {
+              range: { length: 320, units: 'miles' },
+              fuelLevel: 75,
+            },
+          }),
+    };
+  }
+
+  async sendCommand(vehicle: Vehicle, command: VehicleCommand): Promise<void> {
+    await this.delay(1500);
+    const s = this.getState(vehicle.vin);
+    switch (command.type) {
+      case 'lock':         s.locked = true; break;
+      case 'unlock':       s.locked = false; break;
+      case 'startClimate': s.climateOn = true; s.temperature = command.options.temperature; break;
+      case 'stopClimate':  s.climateOn = false; break;
+      case 'startCharge':  s.isCharging = true; break;
+      case 'stopCharge':   s.isCharging = false; break;
+      case 'setTargetSOC': /* no-op for fake */ break;
+    }
+  }
+
+  async fetchEVTripDetails(_vin: string): Promise<EVTripDetail[] | null> {
+    return [
+      { tripId: 'fake-trip-1', date: Date.now() - 86400000, distance: { length: 24.5, units: 'miles' }, energyUsed: 6.2 },
+      { tripId: 'fake-trip-2', date: Date.now() - 172800000, distance: { length: 18.3, units: 'miles' }, energyUsed: 4.7 },
+    ];
+  }
+
+  async sendMFACode(_xid: string, _otpKey: string, _method: MFAMethod): Promise<void> {
+    throw new APIError('MFA not supported by FakeAPIClient', 'general');
+  }
+
+  async verifyMFACode(
+    _xid: string,
+    _otpKey: string,
+    _code: string,
+  ): Promise<{ rememberMeToken: string; sid: string }> {
+    throw new APIError('MFA not supported by FakeAPIClient', 'general');
+  }
+
+  async completeMFALogin(_sid: string, _rmToken: string): Promise<void> {
+    throw new APIError('MFA not supported by FakeAPIClient', 'general');
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/BetterBlueRN/src/api/HyundaiUSClient.ts
+++ b/BetterBlueRN/src/api/HyundaiUSClient.ts
@@ -1,0 +1,579 @@
+/**
+ * Hyundai USA API Client
+ *
+ * Implements the unofficial Hyundai BlueLink US API.
+ * Reference: hyundai_kia_connect_api (Python), bluelinky (TypeScript)
+ */
+import type {
+  APIClient,
+  APIClientConfiguration,
+  AuthToken,
+  ClimateOptions,
+  Distance,
+  EVStatus,
+  EVTripDetail,
+  FuelRange,
+  FuelType,
+  HTTPLogEntry,
+  LockStatus,
+  MFAMethod,
+  Vehicle,
+  VehicleCommand,
+  VehicleLocation,
+  VehicleStatus,
+} from './types';
+import { APIError } from './types';
+
+const BASE_URL = 'https://api.telematics.hyundaiusa.com';
+const CLIENT_ID = 'm66129Bb-em93-SPAHYN-bZ91-am4540zp19920';
+const CLIENT_SECRET = 'v558o935-6nne-423i-baa8';
+const API_HOST = 'api.telematics.hyundaiusa.com';
+
+function payloadTimestamp(): string {
+  const d = new Date();
+  const p = (n: number) => String(n).padStart(2, '0');
+  return (
+    String(d.getFullYear()) +
+    p(d.getMonth() + 1) +
+    p(d.getDate()) +
+    p(d.getHours()) +
+    p(d.getMinutes()) +
+    p(d.getSeconds())
+  );
+}
+
+function celsiusToFahrenheit(celsius: number): number {
+  return Math.round((celsius * 9) / 5 + 32);
+}
+
+function extractNumber(value: unknown): number | undefined {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const n = parseFloat(value);
+    return isNaN(n) ? undefined : n;
+  }
+  return undefined;
+}
+
+export class HyundaiUSClient implements APIClient {
+  private readonly config: APIClientConfiguration;
+  private authToken: AuthToken | null = null;
+  private vehicleCache = new Map<string, Vehicle>();
+
+  constructor(config: APIClientConfiguration) {
+    this.config = config;
+  }
+
+  async initialize(): Promise<void> {
+    await this.ensureAuth();
+  }
+
+  // ── Auth ──────────────────────────────────────────────────────────────
+
+  private async ensureAuth(): Promise<AuthToken> {
+    if (this.authToken && this.authToken.expiresAt > Date.now() + 60_000) {
+      return this.authToken;
+    }
+    if (this.authToken?.refreshToken) {
+      try {
+        return await this.refreshAuthToken(this.authToken.refreshToken);
+      } catch {
+        // fall through to full re-login
+      }
+    }
+    return this.login();
+  }
+
+  private async login(): Promise<AuthToken> {
+    const resp = await this.loggedFetch(
+      `${BASE_URL}/v2/ac/oauth/token`,
+      {
+        method: 'POST',
+        headers: this.baseHeaders(),
+        body: JSON.stringify({
+          username: this.config.username,
+          password: this.config.password,
+        }),
+      },
+      'login',
+    );
+    const json = (await resp.json()) as Record<string, unknown>;
+    if (!json.access_token) {
+      throw new APIError('Invalid login response', 'invalidCredentials');
+    }
+    const token: AuthToken = {
+      accessToken: json.access_token as string,
+      refreshToken: json.refresh_token as string | undefined,
+      expiresAt:
+        Date.now() + parseInt(json.expires_in as string, 10) * 1000,
+    };
+    this.authToken = token;
+    return token;
+  }
+
+  private async refreshAuthToken(refreshToken: string): Promise<AuthToken> {
+    const resp = await this.loggedFetch(
+      `${BASE_URL}/v2/ac/oauth/token/refresh`,
+      {
+        method: 'POST',
+        headers: this.baseHeaders(),
+        body: JSON.stringify({ refresh_token: refreshToken }),
+      },
+      'refreshToken',
+    );
+    const json = (await resp.json()) as Record<string, unknown>;
+    if (!json.access_token) throw new APIError('Refresh failed', 'invalidCredentials');
+    const token: AuthToken = {
+      accessToken: json.access_token as string,
+      refreshToken: json.refresh_token as string | undefined,
+      expiresAt:
+        Date.now() + parseInt(json.expires_in as string, 10) * 1000,
+    };
+    this.authToken = token;
+    return token;
+  }
+
+  // ── Vehicles ──────────────────────────────────────────────────────────
+
+  async fetchVehicles(): Promise<Vehicle[]> {
+    const auth = await this.ensureAuth();
+    const resp = await this.loggedFetch(
+      `${BASE_URL}/ac/v2/enrollment/details/${this.config.username}`,
+      { method: 'GET', headers: this.authorizedHeaders(auth) },
+      'fetchVehicles',
+    );
+    const json = (await resp.json()) as Record<string, unknown>;
+    const enrolled = (json.enrolledVehicleDetails ?? []) as Record<string, unknown>[];
+    const vehicles: Vehicle[] = enrolled.flatMap((entry) => {
+      const details = entry.vehicleDetails as Record<string, unknown> | undefined;
+      if (!details) return [];
+      const vin = details.vin as string | undefined;
+      const regId = details.regid as string | undefined;
+      if (!vin || !regId) return [];
+      const evStatus = details.evStatus as string | undefined;
+      const fuelType: FuelType =
+        evStatus === 'E' ? 'electric' : evStatus === 'P' ? 'phev' : 'gas';
+      const odometerRaw = extractNumber(details.odometer);
+      const vehicle: Vehicle = {
+        id: vin,
+        vin,
+        regId,
+        model: (details.nickName as string | undefined) ?? vin,
+        accountId: this.config.accountId,
+        fuelType,
+        generation: parseInt((details.vehicleGeneration as string | undefined) ?? '2', 10),
+        isHidden: false,
+        sortOrder: 0,
+        backgroundColorName: 'default',
+        chargePortType: 'CCS1',
+        enableSeatHeatControls: false,
+        odometer: odometerRaw != null ? { length: odometerRaw, units: 'miles' } : undefined,
+      };
+      return [vehicle];
+    });
+    vehicles.forEach((v) => this.vehicleCache.set(v.vin, v));
+    return vehicles;
+  }
+
+  // ── Vehicle Status ────────────────────────────────────────────────────
+
+  async fetchVehicleStatus(
+    vin: string,
+    regId: string,
+    _vehicleKey?: string,
+    cached = true,
+  ): Promise<VehicleStatus> {
+    const auth = await this.ensureAuth();
+    const vehicle = this.vehicleCache.get(vin);
+    const resp = await this.loggedFetch(
+      `${BASE_URL}/ac/v2/rcs/rvs/vehicleStatus`,
+      {
+        method: 'GET',
+        headers: this.authorizedHeaders(
+          auth,
+          vehicle ?? { vin, regId, generation: 2 },
+          /* refresh */ !cached,
+        ),
+      },
+      'fetchVehicleStatus',
+    );
+    const json = (await resp.json()) as Record<string, unknown>;
+    const s = (json.vehicleStatus ?? {}) as Record<string, unknown>;
+    return this.parseVehicleStatus(s, vehicle);
+  }
+
+  // ── Commands ──────────────────────────────────────────────────────────
+
+  async sendCommand(vehicle: Vehicle, command: VehicleCommand): Promise<void> {
+    const auth = await this.ensureAuth();
+    const url = this.commandURL(command, vehicle);
+    const body = this.commandBody(command, vehicle);
+    const bodyStr = Object.keys(body).length > 0 ? JSON.stringify(body) : undefined;
+    const resp = await this.loggedFetch(
+      url,
+      {
+        method: 'POST',
+        headers: this.authorizedHeaders(auth, vehicle),
+        body: bodyStr,
+      },
+      'sendCommand',
+    );
+    const json = (await resp.json().catch(() => ({}))) as Record<string, unknown>;
+    if (json.isBlueLinkServicePinValid === 'invalid') {
+      throw new APIError('Invalid PIN', 'invalidPin');
+    }
+  }
+
+  // ── EV Trip Details ───────────────────────────────────────────────────
+
+  async fetchEVTripDetails(vin: string): Promise<EVTripDetail[] | null> {
+    const auth = await this.ensureAuth();
+    const vehicle = this.vehicleCache.get(vin);
+    if (!vehicle) return null;
+    const headers = {
+      ...this.authorizedHeaders(auth, vehicle),
+      userId: this.config.username,
+      access_token: auth.accessToken,
+    };
+    try {
+      const resp = await this.loggedFetch(
+        `${BASE_URL}/ac/v2/ts/alerts/maintenance/evTripDetails`,
+        { method: 'GET', headers },
+        'fetchEVTripDetails',
+      );
+      const json = (await resp.json()) as Record<string, unknown>;
+      return this.parseTripDetails(json);
+    } catch {
+      return null;
+    }
+  }
+
+  // ── MFA (not supported) ───────────────────────────────────────────────
+
+  supportsMFA(): boolean {
+    return false;
+  }
+
+  async sendMFACode(_xid: string, _otpKey: string, _method: MFAMethod): Promise<void> {
+    throw new APIError('MFA not supported by Hyundai US', 'general');
+  }
+
+  async verifyMFACode(
+    _xid: string,
+    _otpKey: string,
+    _code: string,
+  ): Promise<{ rememberMeToken: string; sid: string }> {
+    throw new APIError('MFA not supported by Hyundai US', 'general');
+  }
+
+  async completeMFALogin(_sid: string, _rmToken: string): Promise<void> {
+    throw new APIError('MFA not supported by Hyundai US', 'general');
+  }
+
+  // ── Private Helpers ───────────────────────────────────────────────────
+
+  private baseHeaders(): Record<string, string> {
+    return {
+      client_id: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+      Host: API_HOST,
+      'User-Agent': 'okhttp/3.12.0',
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/plain, */*',
+    };
+  }
+
+  private authorizedHeaders(
+    auth: AuthToken,
+    vehicle?: Pick<Vehicle, 'vin' | 'regId' | 'generation'>,
+    refresh = false,
+  ): Record<string, string> {
+    const headers: Record<string, string> = {
+      ...this.baseHeaders(),
+      accessToken: auth.accessToken,
+      language: '0',
+      to: 'ISS',
+      encryptFlag: 'false',
+      from: 'SPA',
+      offset: '-5',
+      brandIndicator: 'H',
+      origin: `https://${API_HOST}`,
+      referer: `https://${API_HOST}/login`,
+      username: this.config.username,
+      blueLinkServicePin: this.config.pin,
+      refresh: refresh ? 'true' : 'false',
+      payloadGenerated: payloadTimestamp(),
+      includeNonConnectedVehicles: 'Y',
+    };
+    if (vehicle) {
+      headers.gen = String(vehicle.generation ?? 2);
+      headers.registrationId = vehicle.regId;
+      headers.vin = vehicle.vin;
+      headers['APPCLOUD-VIN'] = vehicle.vin;
+    }
+    return headers;
+  }
+
+  private commandURL(command: VehicleCommand, vehicle: Vehicle): string {
+    const isEV = vehicle.fuelType === 'electric' || vehicle.fuelType === 'phev';
+    switch (command.type) {
+      case 'unlock':       return `${BASE_URL}/ac/v2/rcs/rdo/on`;
+      case 'lock':         return `${BASE_URL}/ac/v2/rcs/rdo/off`;
+      case 'startClimate': return isEV ? `${BASE_URL}/ac/v2/evc/fatc/start` : `${BASE_URL}/ac/v2/rcs/rsc/start`;
+      case 'stopClimate':  return isEV ? `${BASE_URL}/ac/v2/evc/fatc/stop`  : `${BASE_URL}/ac/v2/rcs/rsc/stop`;
+      case 'startCharge':  return `${BASE_URL}/ac/v2/evc/charge/start`;
+      case 'stopCharge':   return `${BASE_URL}/ac/v2/evc/charge/stop`;
+      case 'setTargetSOC': return `${BASE_URL}/ac/v2/evc/charge/targetsoc/set`;
+    }
+  }
+
+  private commandBody(
+    command: VehicleCommand,
+    vehicle: Vehicle,
+  ): Record<string, unknown> {
+    if (command.type === 'startClimate') {
+      const opts = command.options;
+      const fahrenheit = celsiusToFahrenheit(opts.temperature);
+      const isEV = vehicle.fuelType === 'electric' || vehicle.fuelType === 'phev';
+      if (isEV) {
+        const body: Record<string, unknown> = {
+          airCtrl: opts.heating ? 1 : 0,
+          airTemp: { value: String(fahrenheit), unit: 1 },
+          defrost: opts.defrost,
+          heating1: opts.heating ? 1 : 0,
+        };
+        if (vehicle.generation >= 3) {
+          body.igniOnDuration = opts.duration;
+          body.seatHeaterVentInfo = this.seatHeaterInfo(opts);
+        }
+        return body;
+      }
+      return {
+        Ims: 0,
+        airCtrl: opts.heating ? 1 : 0,
+        airTemp: { unit: 1, value: fahrenheit },
+        defrost: opts.defrost,
+        heating1: opts.heating ? 1 : 0,
+        igniOnDuration: opts.duration,
+        seatHeaterVentInfo: this.seatHeaterInfo(opts),
+        username: this.config.username,
+        vin: vehicle.vin,
+      };
+    }
+    if (command.type === 'setTargetSOC') {
+      return {
+        targetSOClist: [
+          { targetSOClevel: command.acLevel, plugType: 1 },
+          { targetSOClevel: command.dcLevel, plugType: 0 },
+        ],
+      };
+    }
+    return {};
+  }
+
+  private seatHeaterInfo(opts: ClimateOptions): Record<string, number> {
+    return {
+      driverSeat: opts.frontLeftSeatHeat,
+      passengerSeat: opts.frontRightSeatHeat,
+      rearLeftSeat: 0,
+      rearRightSeat: 0,
+    };
+  }
+
+  // ── Response Parsing ──────────────────────────────────────────────────
+
+  private parseVehicleStatus(
+    s: Record<string, unknown>,
+    vehicle?: Vehicle,
+  ): VehicleStatus {
+    return {
+      lastUpdated: Date.now(),
+      syncDate: this.parseSyncDate(s),
+      lockStatus: this.parseLockStatus(s),
+      climateStatus: this.parseClimateStatus(s),
+      evStatus: this.parseEVStatus(s, vehicle?.fuelType),
+      gasRange: this.parseGasRange(s, vehicle?.fuelType),
+      location: this.parseLocation(s),
+      battery12V: this.parseBattery12V(s),
+      doorOpen: this.parseDoorOpen(s),
+      trunkOpen: s.trunkOpen as boolean | undefined,
+      hoodOpen: s.hoodOpen as boolean | undefined,
+    };
+  }
+
+  private parseLockStatus(s: Record<string, unknown>): LockStatus {
+    return { locked: (s.doorLock as boolean | undefined) ?? false };
+  }
+
+  private parseClimateStatus(s: Record<string, unknown>) {
+    const airTemp = (s.airTemp ?? {}) as Record<string, unknown>;
+    return {
+      airControlOn: (s.airCtrlOn as boolean | undefined) ?? false,
+      defrostOn: (s.defrost as boolean | undefined) ?? false,
+      temperature: airTemp.value != null
+        ? parseFloat(airTemp.value as string)
+        : undefined,
+    };
+  }
+
+  private parseEVStatus(
+    s: Record<string, unknown>,
+    fuelType?: FuelType,
+  ): EVStatus | undefined {
+    if (fuelType === 'gas') return undefined;
+    const ev = (s.evStatus ?? {}) as Record<string, unknown>;
+    const batteryLevel = extractNumber(ev.batteryStatus);
+    if (batteryLevel == null) return undefined;
+
+    const drvDistances = (ev.drvDistance ?? []) as Record<string, unknown>[];
+    let range: Distance = { length: 0, units: 'miles' };
+    for (const d of drvDistances) {
+      const rbf = (d.rangeByFuel ?? {}) as Record<string, unknown>;
+      const evMode = ((rbf.evModeRange ?? rbf.totalAvailableRange) ?? {}) as Record<string, unknown>;
+      const val = extractNumber(evMode.value);
+      if (val != null) {
+        range = { length: val, units: extractNumber(evMode.unit) === 3 ? 'miles' : 'km' };
+        break;
+      }
+    }
+
+    const remainTime2 = (ev.remainTime2 ?? {}) as Record<string, unknown>;
+    const atc = (remainTime2.atc ?? {}) as Record<string, unknown>;
+    const chargeMinutes = extractNumber(atc.value) ?? 0;
+    const batteryPlugin = extractNumber(ev.batteryPlugin) ?? 0;
+    const isCharging = (ev.batteryCharge as boolean | undefined) ?? false;
+
+    const targetSocList = (
+      ((ev.reservChargeInfos as Record<string, unknown> | undefined) ?? {})
+        .targetSOClist ?? []
+    ) as Record<string, unknown>[];
+    let acTargetSOC: number | undefined;
+    let dcTargetSOC: number | undefined;
+    for (const t of targetSocList) {
+      const pt = extractNumber(t.plugType);
+      const soc = extractNumber(t.targetSOClevel);
+      if (pt === 1) acTargetSOC = soc;
+      else if (pt === 0) dcTargetSOC = soc;
+    }
+
+    return {
+      batteryLevel,
+      range,
+      chargeStatus: isCharging ? 'charging' : 'not_charging',
+      isCharging,
+      isPluggedIn: batteryPlugin > 0,
+      chargeRemainingMinutes: chargeMinutes,
+      plugType: batteryPlugin === 0 ? 'unplugged' : batteryPlugin === 2 ? 'dc' : 'ac',
+      acTargetSOC,
+      dcTargetSOC,
+    };
+  }
+
+  private parseGasRange(
+    s: Record<string, unknown>,
+    fuelType?: FuelType,
+  ): FuelRange | undefined {
+    if (fuelType === 'electric') return undefined;
+    const fuelLevel = extractNumber(s.fuelLevel);
+    if (fuelLevel == null) return undefined;
+    const dte = (s.dte ?? {}) as Record<string, unknown>;
+    const val = extractNumber(dte.value);
+    if (val == null) return undefined;
+    return {
+      range: { length: val, units: extractNumber(dte.unit) === 3 ? 'miles' : 'km' },
+      fuelLevel,
+    };
+  }
+
+  private parseLocation(s: Record<string, unknown>): VehicleLocation | undefined {
+    const loc = (s.vehicleLocation ?? {}) as Record<string, unknown>;
+    const coord = (loc.coord ?? {}) as Record<string, unknown>;
+    const lat = extractNumber(coord.lat);
+    const lon = extractNumber(coord.lon);
+    if (lat == null || lon == null) return undefined;
+    return { latitude: lat, longitude: lon };
+  }
+
+  private parseDoorOpen(s: Record<string, unknown>) {
+    const d = (s.doorOpen ?? {}) as Record<string, unknown>;
+    return {
+      frontLeft: (extractNumber(d.frontLeft) ?? 0) !== 0,
+      frontRight: (extractNumber(d.frontRight) ?? 0) !== 0,
+      rearLeft: (extractNumber(d.backLeft) ?? 0) !== 0,
+      rearRight: (extractNumber(d.backRight) ?? 0) !== 0,
+    };
+  }
+
+  private parseBattery12V(s: Record<string, unknown>): number | undefined {
+    const bat = (s.battery ?? {}) as Record<string, unknown>;
+    return extractNumber(bat.batSoc);
+  }
+
+  private parseSyncDate(s: Record<string, unknown>): number | undefined {
+    const dt = s.dateTime as string | undefined;
+    if (!dt) return undefined;
+    const d = new Date(dt);
+    return isNaN(d.getTime()) ? undefined : d.getTime();
+  }
+
+  private parseTripDetails(json: Record<string, unknown>): EVTripDetail[] {
+    const trips = (json.tripdetails ?? []) as Record<string, unknown>[];
+    return trips.map((t, i) => ({
+      tripId: String(i),
+      date: Date.now(),
+      distance: { length: extractNumber(t.distance) ?? 0, units: 'miles' as const },
+      energyUsed: extractNumber(t.totalused) ?? 0,
+    }));
+  }
+
+  // ── HTTP Helper ───────────────────────────────────────────────────────
+
+  private async loggedFetch(
+    url: string,
+    init: RequestInit,
+    type: string,
+  ): Promise<Response> {
+    const start = Date.now();
+    const logId = Math.random().toString(36).slice(2);
+    const reqHeaders = (init.headers ?? {}) as Record<string, string>;
+    try {
+      const response = await fetch(url, init);
+      const text = await response.text();
+      const durationMs = Date.now() - start;
+      const log: HTTPLogEntry = {
+        id: logId,
+        accountId: this.config.accountId,
+        timestamp: start,
+        method: (init.method ?? 'GET').toUpperCase(),
+        url,
+        requestHeaders: reqHeaders,
+        requestBody: init.body != null ? String(init.body) : undefined,
+        responseStatus: response.status,
+        responseBody: text,
+        durationMs,
+      };
+      this.config.onHTTPLog?.(log);
+      if (!response.ok) {
+        let errMsg = `HTTP ${response.status}`;
+        try {
+          const body = JSON.parse(text) as Record<string, unknown>;
+          errMsg = (body.message ?? body.error ?? errMsg) as string;
+        } catch { /* ignore */ }
+        throw new APIError(errMsg, 'serverError');
+      }
+      return new Response(text, { status: response.status, headers: response.headers });
+    } catch (err) {
+      if (err instanceof APIError) throw err;
+      this.config.onHTTPLog?.({
+        id: logId,
+        accountId: this.config.accountId,
+        timestamp: start,
+        method: (init.method ?? 'GET').toUpperCase(),
+        url,
+        error: String(err),
+        durationMs: Date.now() - start,
+      });
+      throw new APIError(String(err), 'serverError', err);
+    }
+  }
+}

--- a/BetterBlueRN/src/api/KiaUSClient.ts
+++ b/BetterBlueRN/src/api/KiaUSClient.ts
@@ -1,0 +1,657 @@
+/**
+ * Kia USA API Client
+ *
+ * Implements the unofficial Kia Connect US API with MFA support.
+ * Reference: hyundai_kia_connect_api (Python), bluelinky (TypeScript)
+ *
+ * Key characteristics:
+ * - Session-based auth (23-hour lifetime); session ID lives in response header `sid`
+ * - Device ID is a stable uppercase UUID; clientUUID is UUID5 of deviceId
+ * - MFA triggered when `payload.otpKey` appears in login response
+ * - Real-time status refresh via `rems/rvs` before cached `cmm/gvi`
+ */
+import type {
+  APIClient,
+  APIClientConfiguration,
+  AuthToken,
+  Distance,
+  EVStatus,
+  EVTripDetail,
+  FuelRange,
+  FuelType,
+  HTTPLogEntry,
+  MFAInfo,
+  MFAMethod,
+  Vehicle,
+  VehicleCommand,
+  VehicleLocation,
+  VehicleStatus,
+} from './types';
+import { APIError } from './types';
+
+const BASE_URL = 'https://api.owners.kia.com';
+const LOGIN_TOKEN_LIFETIME_MS = 23 * 3600 * 1000;
+const DNS_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+
+// ── UUID5 helper ─────────────────────────────────────────────────────────────
+
+function uuidToBytes(uuid: string): Uint8Array {
+  const hex = uuid.replace(/-/g, '');
+  const bytes = new Uint8Array(16);
+  for (let i = 0; i < 16; i++) bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  return bytes;
+}
+
+function bytesToUUID(b: Uint8Array): string {
+  const h = Array.from(b).map((x) => x.toString(16).padStart(2, '0')).join('');
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;
+}
+
+async function generateUUID5(namespace: string, name: string): Promise<string> {
+  const nsBytes = uuidToBytes(namespace);
+  const nameBytes = new TextEncoder().encode(name);
+  const data = new Uint8Array(nsBytes.length + nameBytes.length);
+  data.set(nsBytes);
+  data.set(nameBytes, nsBytes.length);
+  const hashBuf = await crypto.subtle.digest('SHA-1', data);
+  const hash = new Uint8Array(hashBuf);
+  hash[6] = (hash[6] & 0x0f) | 0x50; // version 5
+  hash[8] = (hash[8] & 0x3f) | 0x80; // variant
+  return bytesToUUID(hash.slice(0, 16));
+}
+
+// ── Number extraction helper ──────────────────────────────────────────────────
+
+function extractNumber(value: unknown): number | undefined {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const n = parseFloat(value);
+    return isNaN(n) ? undefined : n;
+  }
+  return undefined;
+}
+
+function isJSONBoolean(value: unknown): boolean {
+  return value === true || value === false;
+}
+
+// ── Temperature helper (Kia US always expects Fahrenheit, 62–82°F range) ──────
+
+function kiaUSAirTemp(celsius: number): { value: string; unit: 1 } {
+  const fahrenheit = Math.round((celsius * 9) / 5 + 32);
+  let value: string;
+  if (fahrenheit < 62) value = 'LOW';
+  else if (fahrenheit > 82) value = 'HIGH';
+  else value = String(fahrenheit);
+  return { value, unit: 1 };
+}
+
+// ── Client ────────────────────────────────────────────────────────────────────
+
+export class KiaUSClient implements APIClient {
+  private readonly config: APIClientConfiguration;
+  private readonly deviceId: string;
+  private clientUUID = '';
+  private authToken: AuthToken | null = null;
+  private vehicleCache = new Map<string, Vehicle>();
+
+  constructor(config: APIClientConfiguration) {
+    this.config = config;
+    this.deviceId = config.deviceId ?? crypto.randomUUID().toUpperCase();
+  }
+
+  async initialize(): Promise<void> {
+    this.clientUUID = await generateUUID5(DNS_NAMESPACE, this.deviceId);
+    await this.ensureAuth();
+  }
+
+  // ── Auth ────────────────────────────────────────────────────────────────
+
+  private get apiURL(): string {
+    return `${BASE_URL}/apigw/v1/`;
+  }
+
+  private async ensureAuth(): Promise<AuthToken> {
+    if (this.authToken && this.authToken.expiresAt > Date.now() + 60_000) {
+      return this.authToken;
+    }
+    return this.login();
+  }
+
+  private async login(): Promise<AuthToken> {
+    return this.loginWithMFA(undefined, this.config.rememberMeToken);
+  }
+
+  private async loginWithMFA(
+    sid: string | undefined,
+    rmToken: string | undefined,
+  ): Promise<AuthToken> {
+    const headers: Record<string, string> = { ...this.baseHeaders() };
+    if (rmToken) headers.rmtoken = rmToken;
+    if (sid) headers.sid = sid;
+
+    const body = {
+      deviceKey: this.deviceId,
+      deviceType: 2,
+      tncFlag: 1,
+      userCredential: {
+        userId: this.config.username,
+        password: this.config.password,
+      },
+    };
+
+    const { text, responseHeaders } = await this.loggedFetchRaw(
+      `${this.apiURL}prof/authUser`,
+      { method: 'POST', headers, body: JSON.stringify(body) },
+      'login',
+    );
+
+    const json = JSON.parse(text) as Record<string, unknown>;
+    this.checkForKiaErrors(json);
+
+    // Check for MFA requirement
+    const payload = json.payload as Record<string, unknown> | undefined;
+    if (payload?.otpKey) {
+      const xid = responseHeaders.xid ?? responseHeaders.Xid ?? responseHeaders.XID ?? '';
+      const mfaInfo: MFAInfo = {
+        xid,
+        otpKey: payload.otpKey as string,
+        email: payload.email as string | undefined,
+        phone: payload.phone as string | undefined,
+      };
+      throw new APIError('MFA required', 'requiresMFA', undefined, mfaInfo);
+    }
+
+    const sessionId =
+      responseHeaders.sid ?? responseHeaders.Sid ?? responseHeaders.SID;
+    if (!sessionId) {
+      throw new APIError('Login response missing session ID header', 'serverError');
+    }
+
+    // Check for rotated rmToken
+    const rotatedRmToken =
+      responseHeaders.rmToken ?? responseHeaders.rmtoken ?? responseHeaders.RmToken;
+    if (rotatedRmToken) {
+      this.config.onRememberMeTokenRotated?.(rotatedRmToken);
+    }
+
+    const token: AuthToken = {
+      accessToken: sessionId,
+      refreshToken: sessionId,
+      expiresAt: Date.now() + LOGIN_TOKEN_LIFETIME_MS,
+    };
+    this.authToken = token;
+    return token;
+  }
+
+  supportsMFA(): boolean {
+    return true;
+  }
+
+  async sendMFACode(xid: string, otpKey: string, method: MFAMethod): Promise<void> {
+    const headers: Record<string, string> = {
+      ...this.baseHeaders(),
+      otpkey: otpKey,
+      notifytype: method === 'email' ? 'EMAIL' : 'SMS',
+      xid,
+    };
+    const { text } = await this.loggedFetchRaw(
+      `${this.apiURL}cmm/sendOTP`,
+      { method: 'POST', headers, body: JSON.stringify({}) },
+      'sendMFA',
+    );
+    this.checkForKiaErrors(JSON.parse(text) as Record<string, unknown>);
+  }
+
+  async verifyMFACode(
+    xid: string,
+    otpKey: string,
+    code: string,
+  ): Promise<{ rememberMeToken: string; sid: string }> {
+    const headers: Record<string, string> = {
+      ...this.baseHeaders(),
+      otpkey: otpKey,
+      xid,
+    };
+    const { text, responseHeaders } = await this.loggedFetchRaw(
+      `${this.apiURL}cmm/verifyOTP`,
+      { method: 'POST', headers, body: JSON.stringify({ otp: code }) },
+      'verifyMFA',
+    );
+    this.checkForKiaErrors(JSON.parse(text) as Record<string, unknown>);
+    const rmToken =
+      responseHeaders.rmToken ?? responseHeaders.rmtoken ?? responseHeaders.RmToken;
+    const sid = responseHeaders.sid ?? responseHeaders.Sid ?? responseHeaders.SID;
+    if (!rmToken || !sid) {
+      throw new APIError('Verify OTP response missing tokens', 'serverError');
+    }
+    return { rememberMeToken: rmToken, sid };
+  }
+
+  async completeMFALogin(sid: string, rmToken: string): Promise<void> {
+    await this.loginWithMFA(sid, rmToken);
+  }
+
+  // ── Vehicles ────────────────────────────────────────────────────────────
+
+  async fetchVehicles(): Promise<Vehicle[]> {
+    const auth = await this.ensureAuth();
+    const { text } = await this.loggedFetchRaw(
+      `${this.apiURL}ownr/gvl`,
+      { method: 'GET', headers: this.authorizedHeaders(auth) },
+      'fetchVehicles',
+    );
+    const json = JSON.parse(text) as Record<string, unknown>;
+    this.checkForKiaErrors(json);
+    const payload = (json.payload ?? {}) as Record<string, unknown>;
+    const summary = (payload.vehicleSummary ?? []) as Record<string, unknown>[];
+    const vehicles: Vehicle[] = summary.flatMap((entry) => {
+      const vin = entry.vin as string | undefined;
+      const regId = entry.vehicleIdentifier as string | undefined;
+      const vehicleKey = entry.vehicleKey as string | undefined;
+      const fuelTypeNum = extractNumber(entry.fuelType);
+      if (!vin || !regId || !vehicleKey || fuelTypeNum == null) return [];
+      const fuelType: FuelType = fuelTypeNum === 4 ? 'electric' : 'gas';
+      const vehicle: Vehicle = {
+        id: vin,
+        vin,
+        regId,
+        model: (entry.nickName as string | undefined) ?? vin,
+        accountId: this.config.accountId,
+        fuelType,
+        generation: parseInt((entry.genType as string | undefined) ?? '2', 10),
+        vehicleKey,
+        isHidden: false,
+        sortOrder: 0,
+        backgroundColorName: 'default',
+        chargePortType: 'CCS1',
+        enableSeatHeatControls: false,
+        odometer: extractNumber(entry.mileage) != null
+          ? { length: extractNumber(entry.mileage)!, units: 'miles' }
+          : undefined,
+      };
+      return [vehicle];
+    });
+    vehicles.forEach((v) => this.vehicleCache.set(v.vin, v));
+    return vehicles;
+  }
+
+  // ── Vehicle Status ────────────────────────────────────────────────────────
+
+  async fetchVehicleStatus(
+    vin: string,
+    _regId: string,
+    vehicleKey?: string,
+    cached = true,
+  ): Promise<VehicleStatus> {
+    const auth = await this.ensureAuth();
+    const vehicle = this.vehicleCache.get(vin);
+    const vKey = vehicleKey ?? vehicle?.vehicleKey;
+
+    if (!cached) {
+      await this.triggerRealTimeRefresh(auth, vKey);
+    }
+
+    const reqBody = {
+      vehicleConfigReq: {
+        airTempRange: '0', maintenance: '1', seatHeatCoolOption: '0',
+        vehicle: '1', vehicleFeature: '0',
+      },
+      vehicleInfoReq: {
+        drivingActivty: '0', dtc: '1', enrollment: '1', functionalCards: '0',
+        location: '1', vehicleStatus: '1', weather: '0',
+      },
+      vinKey: [vKey ?? ''],
+    };
+
+    const { text } = await this.loggedFetchRaw(
+      `${this.apiURL}cmm/gvi`,
+      {
+        method: 'POST',
+        headers: this.authorizedHeaders(auth, vKey),
+        body: JSON.stringify(reqBody),
+      },
+      'fetchVehicleStatus',
+    );
+    const json = JSON.parse(text) as Record<string, unknown>;
+    this.checkForKiaErrors(json);
+    return this.parseVehicleStatus(json, vehicle);
+  }
+
+  private async triggerRealTimeRefresh(
+    auth: AuthToken,
+    vehicleKey: string | undefined,
+  ): Promise<void> {
+    try {
+      const { text } = await this.loggedFetchRaw(
+        `${this.apiURL}rems/rvs`,
+        {
+          method: 'POST',
+          headers: this.authorizedHeaders(auth, vehicleKey),
+          body: JSON.stringify({ requestType: 0 }),
+        },
+        'realTimeRefresh',
+      );
+      this.checkForKiaErrors(JSON.parse(text) as Record<string, unknown>);
+    } catch (err) {
+      if (err instanceof APIError && err.errorType === 'invalidCredentials') throw err;
+      // swallow — a stale snapshot beats surfacing an error
+    }
+  }
+
+  // ── Commands ──────────────────────────────────────────────────────────────
+
+  async sendCommand(vehicle: Vehicle, command: VehicleCommand): Promise<void> {
+    const auth = await this.ensureAuth();
+    const url = this.commandURL(command);
+    const body = this.commandBody(command, vehicle);
+    const method = this.commandMethod(command);
+    const { text } = await this.loggedFetchRaw(url, {
+      method,
+      headers: this.authorizedHeaders(auth, vehicle.vehicleKey),
+      body: method === 'GET' ? undefined : JSON.stringify(body),
+    }, 'sendCommand');
+    this.checkForKiaErrors(JSON.parse(text) as Record<string, unknown>);
+  }
+
+  async fetchEVTripDetails(_vin: string): Promise<EVTripDetail[] | null> {
+    return null; // Kia US does not expose EV trip details
+  }
+
+  // ── Private Helpers ────────────────────────────────────────────────────────
+
+  private commandMethod(command: VehicleCommand): 'GET' | 'POST' {
+    return command.type === 'stopClimate' || command.type === 'stopCharge' ? 'GET' : 'POST';
+  }
+
+  private commandURL(command: VehicleCommand): string {
+    switch (command.type) {
+      case 'lock':         return `${this.apiURL}rems/door/lock`;
+      case 'unlock':       return `${this.apiURL}rems/door/unlock`;
+      case 'startClimate': return `${this.apiURL}rems/start`;
+      case 'stopClimate':  return `${this.apiURL}rems/stop`;
+      case 'startCharge':  return `${this.apiURL}evc/charge`;
+      case 'stopCharge':   return `${this.apiURL}evc/cancel`;
+      case 'setTargetSOC': return `${this.apiURL}evc/sts`;
+    }
+  }
+
+  private commandBody(
+    command: VehicleCommand,
+    _vehicle: Vehicle,
+  ): Record<string, unknown> {
+    if (command.type === 'startClimate') {
+      const opts = command.options;
+      const seats = {
+        driverSeat:    this.seatSetting(opts.frontLeftSeatHeat),
+        passengerSeat: this.seatSetting(opts.frontRightSeatHeat),
+        rearLeftSeat:  this.seatSetting(0),
+        rearRightSeat: this.seatSetting(0),
+      };
+      const remoteClimate: Record<string, unknown> = {
+        airCtrl: opts.heating,
+        defrost: opts.defrost,
+        airTemp: kiaUSAirTemp(opts.temperature),
+        ignitionOnDuration: { unit: 4, value: opts.duration },
+        heatingAccessory: { steeringWheel: 0, steeringWheelStep: 0, rearWindow: 0, sideMirror: 0 },
+      };
+      const hasSeats = Object.values(seats).some(
+        (s) => (s as Record<string, number>).heatVentType !== 0,
+      );
+      if (hasSeats) remoteClimate.heatVentSeat = seats;
+      return { remoteClimate };
+    }
+    if (command.type === 'startCharge') return { chargeRatio: 100 };
+    if (command.type === 'setTargetSOC') {
+      return {
+        targetSOClist: [
+          { targetSOClevel: command.dcLevel, plugType: 0 },
+          { targetSOClevel: command.acLevel, plugType: 1 },
+        ],
+      };
+    }
+    return {};
+  }
+
+  private seatSetting(heatLevel: number): Record<string, number> {
+    const level = Math.min(Math.max(heatLevel, 0), 3);
+    if (level === 0) return { heatVentType: 0, heatVentLevel: 1, heatVentStep: 0 };
+    return { heatVentType: 1, heatVentLevel: level + 1, heatVentStep: 4 - level };
+  }
+
+  private baseHeaders(): Record<string, string> {
+    const offset = -Math.round(new Date().getTimezoneOffset() / 60);
+    const host = BASE_URL.replace('https://', '');
+    const dateStr = new Date().toUTCString();
+    return {
+      'content-type': 'application/json;charset=utf-8',
+      accept: 'application/json',
+      'accept-encoding': 'gzip, deflate, br',
+      'accept-language': 'en-US,en;q=0.9',
+      'accept-charset': 'utf-8',
+      apptype: 'L',
+      appversion: '7.22.0',
+      clientid: 'SPACL716-APL',
+      clientuuid: this.clientUUID,
+      from: 'SPA',
+      host,
+      language: '0',
+      offset: String(offset),
+      ostype: 'iOS',
+      osversion: '15.8.5',
+      phonebrand: 'iPhone',
+      secretkey: 'sydnat-9kykci-Kuhtep-h5nK',
+      to: 'APIGW',
+      tokentype: 'A',
+      'user-agent': 'KIAPrimo_iOS/37 CFNetwork/1335.0.3.4 Darwin/21.6.0',
+      date: dateStr,
+      deviceid: this.deviceId,
+    };
+  }
+
+  private authorizedHeaders(
+    auth: AuthToken,
+    vehicleKey?: string,
+  ): Record<string, string> {
+    const headers: Record<string, string> = {
+      ...this.baseHeaders(),
+      sid: auth.accessToken,
+    };
+    if (vehicleKey) headers.vinkey = vehicleKey;
+    return headers;
+  }
+
+  private checkForKiaErrors(json: Record<string, unknown>): void {
+    const retCode =
+      (json.retCode as string | undefined) ??
+      ((json.payload as Record<string, unknown> | undefined)?.retCode as string | undefined);
+    if (!retCode || retCode === '0') return;
+    const message = (json.message as string | undefined) ?? `Kia error code: ${retCode}`;
+    if (retCode === '1') throw new APIError(message, 'invalidCredentials');
+    if (retCode === '9001') throw new APIError(message, 'kiaInvalidRequest');
+    throw new APIError(message, 'serverError');
+  }
+
+  // ── Response Parsing ──────────────────────────────────────────────────────
+
+  private parseVehicleStatus(
+    json: Record<string, unknown>,
+    vehicle?: Vehicle,
+  ): VehicleStatus {
+    const payload = (json.payload ?? {}) as Record<string, unknown>;
+    const infoList = (payload.vehicleInfoList ?? []) as Record<string, unknown>[];
+    const lastVehicleInfo = ((infoList[0] ?? {}).lastVehicleInfo ?? {}) as Record<string, unknown>;
+    const statusRpt = (lastVehicleInfo.vehicleStatusRpt ?? {}) as Record<string, unknown>;
+    const vs = (statusRpt.vehicleStatus ?? {}) as Record<string, unknown>;
+
+    return {
+      lastUpdated: Date.now(),
+      syncDate: this.parseSyncDate(vs),
+      lockStatus: { locked: (vs.doorLock as boolean | undefined) ?? false },
+      climateStatus: this.parseClimateStatus(vs),
+      evStatus: this.parseEVStatus(vs),
+      gasRange: this.parseGasRange(vs),
+      location: this.parseLocation(lastVehicleInfo),
+      battery12V: this.parseBattery12V(vs),
+      doorOpen: this.parseDoorOpen(vs),
+      trunkOpen: this.parseTrunk(vs),
+      hoodOpen: this.parseHood(vs),
+      odometer: vehicle?.odometer,
+    };
+  }
+
+  private parseEVStatus(vs: Record<string, unknown>): EVStatus | undefined {
+    const ev = (vs.evStatus ?? {}) as Record<string, unknown>;
+    const batteryLevel = extractNumber(ev.batteryStatus);
+    if (!batteryLevel) return undefined;
+
+    const drvDist = (ev.drvDistance ?? []) as Record<string, unknown>[];
+    const rbf = ((drvDist[0] ?? {}).rangeByFuel ?? {}) as Record<string, unknown>;
+    const evMode = (rbf.evModeRange ?? {}) as Record<string, unknown>;
+    const range: Distance = {
+      length: extractNumber(evMode.value) ?? 0,
+      units: extractNumber(evMode.unit) === 3 ? 'miles' : 'km',
+    };
+
+    const chargeTimes = (ev.remainChargeTime ?? []) as Record<string, unknown>[];
+    const chargeMinutes = extractNumber((chargeTimes[0] ?? {}).value) ?? 0;
+    const batteryPlugin = extractNumber(ev.batteryPlugin) ?? 0;
+    const isCharging = (ev.batteryCharge as boolean | undefined) ?? false;
+
+    const targetSOC = (ev.targetSOC ?? []) as Record<string, unknown>[];
+    let acTargetSOC: number | undefined;
+    let dcTargetSOC: number | undefined;
+    for (const t of targetSOC) {
+      const pt = extractNumber(t.plugType);
+      const soc = extractNumber(t.targetSOClevel);
+      if (pt === 0) dcTargetSOC = soc;
+      else if (pt === 1) acTargetSOC = soc;
+    }
+
+    return {
+      batteryLevel,
+      range,
+      chargeStatus: isCharging ? 'charging' : 'not_charging',
+      isCharging,
+      isPluggedIn: batteryPlugin > 0,
+      chargeRemainingMinutes: chargeMinutes,
+      plugType: batteryPlugin === 0 ? 'unplugged' : batteryPlugin === 2 ? 'dc' : 'ac',
+      acTargetSOC,
+      dcTargetSOC,
+    };
+  }
+
+  private parseGasRange(vs: Record<string, unknown>): FuelRange | undefined {
+    const fuelLevelRaw = vs.fuelLevel;
+    if (fuelLevelRaw == null || isJSONBoolean(fuelLevelRaw)) return undefined;
+    const fuelLevel = extractNumber(fuelLevelRaw);
+    if (fuelLevel == null) return undefined;
+    const dte = (vs.distanceToEmpty ?? {}) as Record<string, unknown>;
+    const rangeVal = extractNumber(dte.value);
+    const rangeUnit = extractNumber(dte.unit);
+    if (rangeVal == null) return undefined;
+    return {
+      range: { length: rangeVal, units: rangeUnit === 3 ? 'miles' : 'km' },
+      fuelLevel,
+    };
+  }
+
+  private parseClimateStatus(vs: Record<string, unknown>) {
+    const climate = (vs.climate ?? {}) as Record<string, unknown>;
+    const airTemp = (climate.airTemp ?? {}) as Record<string, unknown>;
+    return {
+      airControlOn: (climate.airCtrl as boolean | undefined) ?? false,
+      defrostOn: (climate.defrost as boolean | undefined) ?? false,
+      temperature: airTemp.value != null ? parseFloat(airTemp.value as string) : undefined,
+    };
+  }
+
+  private parseSyncDate(vs: Record<string, unknown>): number | undefined {
+    const sd = (vs.syncDate ?? {}) as Record<string, unknown>;
+    const utc = sd.utc as string | undefined;
+    if (!utc) return undefined;
+    // format: yyyyMMddHHmmss
+    const d = new Date(
+      `${utc.slice(0, 4)}-${utc.slice(4, 6)}-${utc.slice(6, 8)}T` +
+      `${utc.slice(8, 10)}:${utc.slice(10, 12)}:${utc.slice(12, 14)}Z`,
+    );
+    return isNaN(d.getTime()) ? undefined : d.getTime();
+  }
+
+  private parseBattery12V(vs: Record<string, unknown>): number | undefined {
+    const bs = vs.batteryStatus as Record<string, unknown> | undefined;
+    if (bs) return extractNumber(bs.stateOfCharge);
+    const bat = vs.battery as Record<string, unknown> | undefined;
+    return bat ? extractNumber(bat.batSoc) : undefined;
+  }
+
+  private parseDoorOpen(vs: Record<string, unknown>) {
+    const d = ((vs.doorStatus ?? vs.doorOpen) ?? {}) as Record<string, unknown>;
+    return {
+      frontLeft: (extractNumber(d.frontLeft) ?? 0) !== 0,
+      frontRight: (extractNumber(d.frontRight) ?? 0) !== 0,
+      rearLeft: (extractNumber(d.rearLeft) ?? 0) !== 0,
+      rearRight: (extractNumber(d.rearRight) ?? 0) !== 0,
+    };
+  }
+
+  private parseTrunk(vs: Record<string, unknown>): boolean | undefined {
+    const ds = vs.doorStatus as Record<string, unknown> | undefined;
+    if (ds) return (extractNumber(ds.trunk) ?? 0) !== 0;
+    return vs.trunkOpen as boolean | undefined;
+  }
+
+  private parseHood(vs: Record<string, unknown>): boolean | undefined {
+    const ds = vs.doorStatus as Record<string, unknown> | undefined;
+    if (ds) return (extractNumber(ds.hood) ?? 0) !== 0;
+    return vs.hoodOpen as boolean | undefined;
+  }
+
+  private parseLocation(lastVehicleInfo: Record<string, unknown>): VehicleLocation | undefined {
+    const loc = (lastVehicleInfo.location ?? {}) as Record<string, unknown>;
+    const coord = (loc.coord ?? {}) as Record<string, unknown>;
+    const lat = extractNumber(coord.lat);
+    const lon = extractNumber(coord.lon);
+    if (lat == null || lon == null) return undefined;
+    return { latitude: lat, longitude: lon };
+  }
+
+  // ── HTTP helper ────────────────────────────────────────────────────────────
+
+  private async loggedFetchRaw(
+    url: string,
+    init: RequestInit,
+    type: string,
+  ): Promise<{ text: string; responseHeaders: Record<string, string> }> {
+    const start = Date.now();
+    const logId = Math.random().toString(36).slice(2);
+    const reqHeaders = (init.headers ?? {}) as Record<string, string>;
+    try {
+      const response = await fetch(url, init);
+      const text = await response.text();
+      const durationMs = Date.now() - start;
+      const responseHeaders: Record<string, string> = {};
+      response.headers.forEach((value, key) => { responseHeaders[key] = value; });
+      this.config.onHTTPLog?.({
+        id: logId, accountId: this.config.accountId, timestamp: start,
+        method: (init.method ?? 'GET').toUpperCase(), url,
+        requestHeaders: reqHeaders,
+        requestBody: init.body != null ? String(init.body) : undefined,
+        responseStatus: response.status, responseHeaders, responseBody: text,
+        durationMs,
+      });
+      if (!response.ok) {
+        throw new APIError(`HTTP ${response.status}`, 'serverError');
+      }
+      return { text, responseHeaders };
+    } catch (err) {
+      if (err instanceof APIError) throw err;
+      this.config.onHTTPLog?.({
+        id: logId, accountId: this.config.accountId, timestamp: start,
+        method: (init.method ?? 'GET').toUpperCase(), url,
+        error: String(err), durationMs: Date.now() - start,
+      });
+      throw new APIError(String(err), 'serverError', err);
+    }
+  }
+}

--- a/BetterBlueRN/src/api/types.ts
+++ b/BetterBlueRN/src/api/types.ts
@@ -1,0 +1,267 @@
+export type Brand = 'hyundai' | 'kia' | 'fake';
+export type Region = 'US' | 'CA' | 'EU' | 'AU' | 'KR';
+export type FuelType = 'gas' | 'electric' | 'phev';
+export type DistanceUnit = 'miles' | 'km';
+export type TemperatureUnit = 'celsius' | 'fahrenheit';
+export type ChargePortType = 'CCS1' | 'CCS2' | 'NACS';
+export type SeatHeatLevel = 0 | 1 | 2 | 3;
+export type MFAMethod = 'sms' | 'email';
+export type BackgroundColorName =
+  | 'default'
+  | 'charcoal'
+  | 'midnight'
+  | 'forest'
+  | 'ocean'
+  | 'crimson';
+
+export interface Account {
+  id: string;
+  username: string;
+  brand: Brand;
+  region: Region;
+  deviceId?: string;
+  rememberMeToken?: string;
+  refreshToken?: string;
+  serializedAuthToken?: string;
+  lastVehiclesFetch?: number;
+}
+
+export interface AuthToken {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt: number;
+  tokenType?: string;
+}
+
+export interface Vehicle {
+  id: string;
+  vin: string;
+  regId: string;
+  model: string;
+  accountId: string;
+  fuelType: FuelType;
+  fuelTypeOverride?: FuelType;
+  generation: number;
+  vehicleKey?: string;
+  customName?: string;
+  isHidden: boolean;
+  sortOrder: number;
+  backgroundColorName: BackgroundColorName;
+  chargePortType: ChargePortType;
+  enableSeatHeatControls: boolean;
+  showClimateDurationOverride?: boolean;
+  primaryColorName?: string;
+  chargingColorName?: string;
+  gasColorName?: string;
+  lockColorName?: string;
+  unlockColorName?: string;
+  startClimateColorName?: string;
+  stopColorName?: string;
+  lastUpdated?: number;
+  syncDate?: number;
+  gasRange?: FuelRange;
+  evStatus?: EVStatus;
+  location?: VehicleLocation;
+  lockStatus?: LockStatus;
+  climateStatus?: ClimateStatus;
+  battery12V?: number;
+  doorOpen?: DoorStatus;
+  trunkOpen?: boolean;
+  hoodOpen?: boolean;
+  tirePressureWarning?: boolean;
+  odometer?: Distance;
+}
+
+export interface Distance {
+  length: number;
+  units: DistanceUnit;
+}
+
+export interface FuelRange {
+  range: Distance;
+  fuelLevel: number;
+}
+
+export interface EVStatus {
+  batteryLevel: number;
+  range: Distance;
+  chargeStatus: 'charging' | 'not_charging' | 'unknown';
+  plugType?: 'unplugged' | 'ac' | 'dc';
+  chargeRemainingMinutes?: number;
+  dcTargetSOC?: number;
+  acTargetSOC?: number;
+  isCharging: boolean;
+  isPluggedIn: boolean;
+}
+
+export interface VehicleLocation {
+  latitude: number;
+  longitude: number;
+  altitude?: number;
+  timestamp?: number;
+}
+
+export interface LockStatus {
+  locked: boolean;
+}
+
+export interface ClimateStatus {
+  airControlOn: boolean;
+  temperature?: number;
+  defrostOn?: boolean;
+  seatHeatLeft?: SeatHeatLevel;
+  seatHeatRight?: SeatHeatLevel;
+}
+
+export interface DoorStatus {
+  frontLeft?: boolean;
+  frontRight?: boolean;
+  rearLeft?: boolean;
+  rearRight?: boolean;
+}
+
+export interface VehicleStatus {
+  lastUpdated: number;
+  syncDate?: number;
+  gasRange?: FuelRange;
+  evStatus?: EVStatus;
+  location?: VehicleLocation;
+  lockStatus?: LockStatus;
+  climateStatus?: ClimateStatus;
+  battery12V?: number;
+  doorOpen?: DoorStatus;
+  trunkOpen?: boolean;
+  hoodOpen?: boolean;
+  tirePressureWarning?: boolean;
+  odometer?: Distance;
+}
+
+export type VehicleCommand =
+  | { type: 'lock' }
+  | { type: 'unlock' }
+  | { type: 'startClimate'; options: ClimateOptions }
+  | { type: 'stopClimate' }
+  | { type: 'startCharge' }
+  | { type: 'stopCharge' }
+  | { type: 'setTargetSOC'; acLevel: number; dcLevel: number };
+
+export interface ClimateOptions {
+  /** Temperature in Celsius; clients convert to Fahrenheit as required by their API. */
+  temperature: number;
+  defrost: boolean;
+  heating: boolean;
+  frontLeftSeatHeat: SeatHeatLevel;
+  frontRightSeatHeat: SeatHeatLevel;
+  duration: number;
+}
+
+export interface ClimatePreset {
+  id: string;
+  vehicleId: string;
+  name: string;
+  iconName: string;
+  isSelected: boolean;
+  sortOrder: number;
+  temperature: number;
+  temperatureUnit: TemperatureUnit;
+  defrost: boolean;
+  frontLeftSeatHeat: SeatHeatLevel;
+  frontRightSeatHeat: SeatHeatLevel;
+  duration: number;
+}
+
+export interface APIClientConfiguration {
+  brand: Brand;
+  region: Region;
+  username: string;
+  password: string;
+  pin: string;
+  accountId: string;
+  deviceId?: string;
+  rememberMeToken?: string;
+  refreshToken?: string;
+  onRememberMeTokenRotated?: (token: string) => void;
+  onHTTPLog?: (log: HTTPLogEntry) => void;
+}
+
+export interface HTTPLogEntry {
+  id: string;
+  accountId: string;
+  timestamp: number;
+  method: string;
+  url: string;
+  requestHeaders?: Record<string, string>;
+  requestBody?: string;
+  responseStatus?: number;
+  responseHeaders?: Record<string, string>;
+  responseBody?: string;
+  error?: string;
+  durationMs: number;
+}
+
+export interface MFAInfo {
+  xid: string;
+  otpKey: string;
+  email?: string;
+  phone?: string;
+  notifyType?: string;
+}
+
+export class APIError extends Error {
+  constructor(
+    message: string,
+    public readonly errorType: APIErrorType,
+    public readonly originalError?: unknown,
+    public readonly mfaInfo?: MFAInfo,
+  ) {
+    super(message);
+    this.name = 'APIError';
+  }
+}
+
+export type APIErrorType =
+  | 'invalidCredentials'
+  | 'invalidPin'
+  | 'invalidVehicleSession'
+  | 'requiresMFA'
+  | 'failedRetryLogin'
+  | 'serverError'
+  | 'concurrentRequest'
+  | 'regionNotSupported'
+  | 'kiaInvalidRequest'
+  | 'general';
+
+export interface AppSettings {
+  distanceUnit: DistanceUnit;
+  temperatureUnit: TemperatureUnit;
+  notificationsEnabled: boolean;
+  debugModeEnabled: boolean;
+}
+
+export interface EVTripDetail {
+  tripId: string;
+  date: number;
+  distance: Distance;
+  energyUsed: number;
+}
+
+export interface APIClient {
+  initialize(): Promise<void>;
+  fetchVehicles(): Promise<Vehicle[]>;
+  fetchVehicleStatus(
+    vin: string,
+    regId: string,
+    vehicleKey?: string,
+    cached?: boolean,
+  ): Promise<VehicleStatus>;
+  sendCommand(vehicle: Vehicle, command: VehicleCommand): Promise<void>;
+  fetchEVTripDetails?(vin: string): Promise<EVTripDetail[] | null>;
+  supportsMFA(): boolean;
+  sendMFACode(xid: string, otpKey: string, method: MFAMethod): Promise<void>;
+  verifyMFACode(
+    xid: string,
+    otpKey: string,
+    code: string,
+  ): Promise<{ rememberMeToken: string; sid: string }>;
+  completeMFALogin(sid: string, rmToken: string): Promise<void>;
+}

--- a/BetterBlueRN/tailwind.config.js
+++ b/BetterBlueRN/tailwind.config.js
@@ -1,0 +1,19 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./app/**/*.{tsx,ts}', './src/**/*.{tsx,ts}'],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      colors: {
+        primary: '#2563eb',
+        'bg-dark': '#0f172a',
+        'surface-dark': '#1e293b',
+        accent: '#3b82f6',
+        danger: '#ef4444',
+        success: '#22c55e',
+        warning: '#f97316',
+      },
+    },
+  },
+  plugins: [],
+};

--- a/BetterBlueRN/tsconfig.json
+++ b/BetterBlueRN/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] }
+  },
+  "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.d.ts", "expo-env.d.ts"]
+}


### PR DESCRIPTION
Adds the full `BetterBlueRN/` scaffold for porting BetterBlue to React Native (Expo).\n\n## What's included\n\n### Project config\n- `package.json` — Expo 52, React Native 0.76, NativeWind v4, Zustand, expo-sqlite, expo-secure-store, expo-router v4\n- `app.json` — Expo config with iOS/Android targets, BlueLink scheme, location + notification plugins\n- `tsconfig.json`, `babel.config.js`, `metro.config.js`, `tailwind.config.js`, `global.css`\n- `SETUP.md` — developer onboarding guide including test account instructions\n\n### API layer (`src/api/`)\n| File | Description |\n|------|-------------|\n| `types.ts` | All shared types mirroring BetterBlueKit Swift models |\n| `HyundaiUSClient.ts` | Hyundai US BlueLink implementation (OAuth login, vehicles, status, all commands, EV trip details) |\n| `KiaUSClient.ts` | Kia US Connect implementation (session auth, 23-hour lifetime, MFA, UUID5 clientUUID, real-time status refresh via `rems/rvs`) |\n| `FakeAPIClient.ts` | In-memory fake client with mutable state for `fake@` / `test@` accounts |\n| `CachedAPIClient.ts` | 5-second TTL cache + request deduplication wrapper |\n| `APIClientFactory.ts` | Creates the correct client based on brand/region |\n\n## Local setup\n\nBecause `pwsh.exe` was unavailable in the Copilot CLI environment, files were committed via this fork. To pull them locally:\n\n```bash\ngit remote add llkirkwood https://github.com/llkirkwood/BetterBlue.git\ngit fetch llkirkwood agents/port-app-to-react-native\ngit merge llkirkwood/agents/port-app-to-react-native\n```\n\nOr simply merge this PR and then `git pull`."