### PR TITLE
Fix Highlight package URL breaking dependency resolution

### DIFF
--- a/BetterBlue.xcodeproj/project.pbxproj
+++ b/BetterBlue.xcodeproj/project.pbxproj
@@ -1073,7 +1073,7 @@
 /* Begin XCRemoteSwiftPackageReference section */
 		EDA7C7782E41A8D700C3174B /* XCRemoteSwiftPackageReference "Highlight" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/nkristek/Highlight?tab=readme-ov-file";
+			repositoryURL = "https://github.com/nkristek/Highlight";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 0.4.0;


### PR DESCRIPTION
The `Highlight` package reference points at `https://github.com/nkristek/Highlight?tab=readme-ov-file`. The `?tab=readme-ov-file` suffix comes from the GitHub web UI rather than the repository URL itself, so git can't clone it:

```
xcodebuild: error: Could not resolve package dependencies:
  Failed to clone repository https://github.com/nkristek/Highlight?tab=readme-ov-file:
    fatal: https://github.com/nkristek/Highlight?tab=readme-ov-file/info/refs not valid: is this a git repository?
```

On a clean checkout this fails package resolution, so the project doesn't build until the URL is fixed locally. Existing clones with a warm SwiftPM cache won't notice.

This drops the query string. Verified with a clean `-derivedDataPath`: package resolution succeeds and the `BetterBlue` scheme builds for both the simulator and a device.